### PR TITLE
update devcontainer project name to match documentation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "SFDX in Docker",
+  "name": "Salesforce Project",
   "dockerFile": "Dockerfile",
   "extensions": [
     "salesforce.salesforcedx-vscode",


### PR DESCRIPTION
This matches the devcontainer.json name property to what we're putting into the documentation.

<img width="293" alt="Screen Shot 2019-08-22 at 9 24 25 AM" src="https://user-images.githubusercontent.com/599418/63529151-76a88a80-c4c1-11e9-9827-eb956d818d10.png">
