### PR TITLE
[Do-not-merge] Force container to always pull

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,5 +6,6 @@
     "redhat.vscode-xml",
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode"
-  ]
+  ],
+  "runArgs": ["--pull=always"]
 }


### PR DESCRIPTION
This is potentially controversial since it was always force a pull of the image even if you have a local cache. This means that, whether you like it or not, you will be force to download MBs of the docker image again.

The only reason I'm suggesting this is because of the issue that if a user just uses `salesforce/salesforcedx` (which, internally, resolves to `salesforce/salesforcedx:latest`) then it doesn't pull the latest version even if what you have is outdated.

So let's discuss if `pull=always` is what we want. Either way this cannot be merged until the next version of Docker CLI comes out because of https://github.com/docker/cli/pull/1498

### Alternatives considered:

[Explicit versioning] We update .devcontainer/Dockerfile each week to contain `salesforce/salesforcedx:x.y.z` instead of relying on `salesforce/salesforcedx:latest`.

**Pros**
* The user knows exactly which version it is.

**Cons**
* The user needs to remember to update her local copy of this repo to get those changes.
* We need to have CI to bump the contents of the .devcontainer/Dockerfile

[Do nothing] Just leave this as-is and have the user determine when to flush the cache

**Pros**
* Everything is within the user's control.

**Cons**
* The user might not know when to flush the cache and might not know that she has an older version of the docker image.

[Add update in Dockerfile] Add a RUN a npm install -g sfdx-cli in the Dockerfile. We cannot use sfdx update since that requires a different installation mechanism using tar.gz. We picked the npm install method from https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_install_cli.htm because

If you've installed Node.js on your computer, you can use npm to install Salesforce CLI. This method lets you install Salesforce CLI from the command line and can be especially useful for continuous integration (CI) use cases.

**Cons**

* Doesn't work The RUN ... still only works for the first time you pull. After that it's in the cache
This goes against the concept of locked dependencies in a Docker image. That means when a user does a docker build or docker run it's not clear that the dependencies in an image has changed.
* Should we do this for all other dependencies then? Where do we draw the line?

[Add a postCreateCommand] This will run another command in the container from VS Code after it starts. According to https://code.visualstudio.com/docs/remote/containers

While less efficient than a custom Dockerfile, you can also use the postCreateCommand property to install additional software that may not be in your base image or for cases where you would prefer not to modify a deployment Dockerfile you are reusing.

**Pros**
* Works and is limited to VS Code. Might even be the intended use case for this.

**Cons**
* Could have unnecessary impact of failed installations, slow installations, etc, but certainly less impactful than doing a pull=always.