### PR TITLE
Set java home to local container path

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,5 +6,8 @@
     "redhat.vscode-xml",
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode"
-  ]
+  ],
+  "settings": {
+    "salesforcedx-vscode-apex.java.home": "/usr/lib/jvm/java-11-openjdk-amd64"
+  }
 }


### PR DESCRIPTION
This PR uses the settings property of devcontainer.json to set the correct path to java.home within the container for apex.