### PR TITLE
Use the latest-slim tag

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,1 +1,1 @@
-FROM salesforce/salesforcedx
+FROM salesforce/salesforcedx:latest-slim


### PR DESCRIPTION
This PR will update the Dockerfile to pull the latest version of the official sfdx image.

Since we updated the tags in the salesforce/salesforcedx docker registry to be `latest-slim` and `latest-full` will need to  use those to get the latest version of the CLI.

Currently, without the new tags, the version of the cli installed now is `7.36.0`